### PR TITLE
Bump github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Stand up docker-compose services
       run: docker-compose up -d
@@ -34,7 +34,7 @@ jobs:
         otp-version: ${{ env.OTP_VERSION }}
 
     - name: Restore the deps cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: deps-cache
       with:
         path: deps
@@ -43,7 +43,7 @@ jobs:
           ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 
     - name: Restore the _build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: build-cache
       with:
         path: _build
@@ -85,7 +85,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Determine the elixir version
       run: echo "ELIXIR_VERSION=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_ENV
@@ -100,7 +100,7 @@ jobs:
         otp-version: ${{ env.OTP_VERSION }}
 
     - name: Restore the deps cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: deps-cache
       with:
         path: deps
@@ -109,7 +109,7 @@ jobs:
           ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 
     - name: Restore the _build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: build-cache
       with:
         path: _build
@@ -144,7 +144,7 @@ jobs:
 
     - name: Create a GitHub Release
       id: create_release
-      uses: NFIBrokerage/create-release@v2
+      uses: NFIBrokerage/create-release@v4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/refresh-dev-cache.yml
+++ b/.github/workflows/refresh-dev-cache.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Determine the elixir version
       run: echo "ELIXIR_VERSION=$(grep -h elixir .tool-versions | awk '{ print $2 }' | awk -F - '{print $1}')" >> $GITHUB_ENV
@@ -53,7 +53,7 @@ jobs:
         otp-version: ${{ env.OTP_VERSION }}
 
     - name: Restore the deps cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: deps-cache
       with:
         path: deps
@@ -62,7 +62,7 @@ jobs:
           ${{ runner.os }}-${{ env.ELIXIR_VERSION }}-${{ env.OTP_VERSION }}-${{ env.MIX_ENV }}-deps-
 
     - name: Restore the _build cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       id: build-cache
       with:
         path: _build


### PR DESCRIPTION
connects https://github.com/NFIBrokerage/support/issues/80

Created locally by script: handles Node.js 16 deprecation warnings by using new action versions